### PR TITLE
Last.fm expects the song durations to be integers

### DIFF
--- a/data/lastfm.js
+++ b/data/lastfm.js
@@ -73,7 +73,7 @@ LFM.track = {
             track: track.title,
             artist: track.artist,
             album: track.album,
-            duration: track.durationMillis / 1000
+            duration: Math.floor(track.durationMillis / 1000)
         };
 
         LFM.call('track.updateNowPlaying', function(result) {
@@ -90,7 +90,7 @@ LFM.track = {
             track: track.title,
             artist: track.artist,
             album: track.album,
-            duration: track.durationMillis / 1000,
+            duration: Math.floor(track.durationMillis / 1000),
 
             timestamp: timestamp
         };


### PR DESCRIPTION
Noticed this minor bug when Last.fm kept returning this error:
{"error":6,"message":"duration is not a valid integer: 216.527","links":[]}
